### PR TITLE
Add support for python3

### DIFF
--- a/sfftp/client.py
+++ b/sfftp/client.py
@@ -1,4 +1,6 @@
 """Collection of client related methods for interacting with Sharefile."""
+from __future__ import print_function
+from builtins import object
 import ftplib
 import netrc
 import re
@@ -24,20 +26,20 @@ class SFFTPClient(object):
 
         for directory in upload_path.split('/')[1:-1]:
             if directory not in self.session.nlst():
-                print "Creating new dir %s" % directory
+                print("Creating new dir %s" % directory)
                 self.session.mkd(directory)
             self.session.cwd(directory)
 
-        print 'Uploading file %s' % filename
-        print 'Upload to directory %s' % self.session.pwd()
+        print('Uploading file %s' % filename)
+        print('Upload to directory %s' % self.session.pwd())
         out = self.session.storbinary('STOR %s' % filename,
                                       open(upload_filepath, 'rb'),
                                       blocksize=8192*1024,
                                       )
         if re.search('Transfer Complete', out):
-            print "Transfer Completed."
+            print("Transfer Completed.")
         else:
-            print "Transfer was unsuccessful. Please check file size"
+            print("Transfer was unsuccessful. Please check file size")
         self.session.close()
 
     def download(self, remote_path, download_path):

--- a/xsautowf/cmd/hclanalysis.py
+++ b/xsautowf/cmd/hclanalysis.py
@@ -1,4 +1,5 @@
 """Python script to analyze HCL related telemetry"""
+from __future__ import print_function
 
 from xsautowf.cmd.processsubmission import JIRA, ArgumentParser
 import datetime
@@ -33,18 +34,18 @@ def time_track(inputdate):
                                           week_endday.year,
                                           week_endday.month,
                                           week_endday.day))
-        print "Resolved Tickets between %s to %s = %d" % (week_firstday,
+        print("Resolved Tickets between %s to %s = %d" % (week_firstday,
                                                           week_endday,
-                                                          len(reslvd_tkts))
+                                                          len(reslvd_tkts)))
         crtd_tkts = JIRA.search_issues(query_crtd_tkts % (week_firstday.year,
                                                           week_firstday.month,
                                                           week_firstday.day,
                                                           week_endday.year,
                                                           week_endday.month,
                                                           week_endday.day))
-        print "Created Tickets between %s to %s = %d\n" % (week_firstday,
+        print("Created Tickets between %s to %s = %d\n" % (week_firstday,
                                                            week_endday,
-                                                           len(crtd_tkts))
+                                                           len(crtd_tkts)))
         date = nextweek_firstday
 
 

--- a/xsautowf/cmd/processsubmission.py
+++ b/xsautowf/cmd/processsubmission.py
@@ -1,5 +1,7 @@
 """Python script for processing a submission"""
+from __future__ import print_function
 
+from builtins import object
 from jira.client import JIRA
 import re
 from xsjira.models import Task, HCLSubmission, GenericSubmission
@@ -48,8 +50,8 @@ class RemoteCopyToCRD(object):  # pylint: disable=R0903
             "place and attach the link.\nThanks,\nSagnik"
             )
         self.crd_ticket.assign_issue(self.crd_user)
-        print "%s Created" % self.crd_ticket.key
-        print self.crd_ticket.get_summary()
+        print("%s Created" % self.crd_ticket.key)
+        print(self.crd_ticket.get_summary())
         return self.crd_ticket
 
 
@@ -81,12 +83,12 @@ def process_submission(options):
     else:
         ticket = GenericSubmission(JIRA, options.ticket)
 
-    print ticket.get_summary()
+    print(ticket.get_summary())
 
     # If copy flag is set, move a copy to the project CRD
     if options.crddup:
         RemoteCopyToCRD().do_remote_copy(ticket)
-        print "## Remote Copy to CRD Done ##\n"
+        print("## Remote Copy to CRD Done ##\n")
 
     #  For non HCL Submission, we need additional parameters as below
     version = options.version
@@ -98,7 +100,7 @@ def process_submission(options):
     #  To display the ack-submission if there is one:
     if ticket.get_type() == 'HCL Submission' and key in ['server', 'nic']:
         (ack_path, ack_filename) = ticket.get_ack_attachment()
-        print "%s found.\nExtracting Product Info.." % ack_filename
+        print("%s found.\nExtracting Product Info.." % ack_filename)
         adict = ticket.get_ack_attachment_dict(ack_path)
 
         if not version:
@@ -109,7 +111,7 @@ def process_submission(options):
             product_name = "%s %s" % (adict['system-manufacturer'].strip(),
                                       adict['product'].strip())
 
-    print "\nDevice Tested: %s" % product_name
+    print("\nDevice Tested: %s" % product_name)
 
     # derive upload_path for FTP upload
     upload_path = "/XenServer HCL/Hardware Certification Logs"

--- a/xscertparser/cmd/acklogparser.py
+++ b/xscertparser/cmd/acklogparser.py
@@ -1,5 +1,7 @@
 """Entry point script for parsing specified log files"""
+from __future__ import print_function
 
+from builtins import range
 from argparse import ArgumentParser
 from xscertparser.utils import extract_file_from_tar
 from xscertparser import xmltojson
@@ -61,29 +63,29 @@ def result_parser(tarfilename, logsubdir):  # pylint: disable=R0914,R0912
 
     # XS-version
     for version in test_conf.getElementsByTagName("global_config"):
-        if 'xs_version' in version.attributes.keys():
+        if 'xs_version' in version.attributes:
             SERVER_DICT['xs_version'] = version.attributes['xs_version'].value
 
     # CPU info and HBA pci-id info
     hba_bus_id_list = []
     for device in test_conf.getElementsByTagName("device"):
-        if 'family' in device.attributes.keys():
+        if 'family' in device.attributes:
             SERVER_DICT['family'] = device.attributes['family'].value
-        if 'stepping' in device.attributes.keys():
+        if 'stepping' in device.attributes:
             SERVER_DICT['stepping'] = device.attributes['stepping'].value
-        if 'model' in device.attributes.keys():
+        if 'model' in device.attributes:
             SERVER_DICT['model'] = device.attributes['model'].value
-        if 'modelname' in device.attributes.keys():
+        if 'modelname' in device.attributes:
             SERVER_DICT['modelname'] = device.attributes['modelname'].value
-        if 'socket_count' in device.attributes.keys():
+        if 'socket_count' in device.attributes:
             SERVER_DICT['sockets'] = device.attributes['socket_count'].value
-        if 'PCI_description' in device.attributes.keys():
+        if 'PCI_description' in device.attributes:
             if device.attributes['PCI_description'].value \
                     not in SERVER_DICT['nics']:
                 SERVER_DICT['nics'].append(
                     device.attributes['PCI_description'].value
                     )
-        if 'device' in device.attributes.keys():
+        if 'device' in device.attributes:
             hba_bus_id_list.append(device.attributes['id'].value)
 
     # Chassis used info                 i
@@ -161,12 +163,12 @@ def display_results(resdict, keys=None):
         'hbas',
     ]
     if keys is None:
-        keys = resdict.keys()
+        keys = list(resdict.keys())
     for key in keys:
         if type(SERVER_DICT[key]) == 'list':
-            print "%50s :" % key, "%-50s" % pprint.pprint(SERVER_DICT[key])
+            print("%50s :" % key, "%-50s" % pprint.pprint(SERVER_DICT[key]))
         else:
-            print "%50s : %s" % (key, SERVER_DICT[key])
+            print("%50s : %s" % (key, SERVER_DICT[key]))
 
 
 def count_test_failures(tarfilename):
@@ -202,7 +204,7 @@ def do_parse(options):
 
     if options.post:
         json = xmltojson.ack_xml_to_json(test_conf_data)
-        print json
+        print(json)
 
     # fail product lists
     if count > 0:
@@ -217,10 +219,10 @@ def do_parse(options):
             if SERVER_DICT['product'] not in MACHINE_DICT['pass']:
                 if SERVER_DICT['product'] not in MACHINE_DICT['fail']:
                     MACHINE_DICT['fail'].append(SERVER_DICT['product'])
-            print "*******%s tests FAILED for %s *********" % (
+            print("*******%s tests FAILED for %s *********" % (
                 count,
                 xenrtmachine,
-                )
+                ))
         else:
             FAILED_DICT[SERVER_DICT['product']] = exception_list
     else:
@@ -230,21 +232,21 @@ def do_parse(options):
             if SERVER_DICT['product'] not in MACHINE_DICT['pass']:
                 MACHINE_DICT['pass'].append(SERVER_DICT['product'])
     if xenrtmachine:
-        print "#"*30
-        print "NICS LISTING HERE"
+        print("#"*30)
+        print("NICS LISTING HERE")
         display_results(NICS_DICT)
-        print "NICS LISTING OVER"
-        print "#"*30
-        print "HBAs HERE"
+        print("NICS LISTING OVER")
+        print("#"*30)
+        print("HBAs HERE")
         display_results(HBAS_DICT)
-        print "HBAs listing over"
-        print "#"*30
-        print "MY PASSED PRODUCTS"
+        print("HBAs listing over")
+        print("#"*30)
+        print("MY PASSED PRODUCTS")
         pprint.pprint(MACHINE_DICT['pass'])
-        print "#"*30
-        print "MY FAIL PRODUCTS"
+        print("#"*30)
+        print("MY FAIL PRODUCTS")
         pprint.pprint(MACHINE_DICT['fail'])
-        print "#"*30, "FAILED_DICT below"
+        print("#"*30, "FAILED_DICT below")
     display_results(FAILED_DICT)
 
 
@@ -274,30 +276,30 @@ def validate_test_run(json):
 
     for dev in json['devices']:
         driver = ""
-        print ""
+        print("")
         if dev['tag'] == 'NA':
-            print dev['PCI_description']
-            print "Driver: %s %s" % (dev['Driver'], dev['Driver_version'])
-            print "Firmware: %s" % dev['Firmware_version']
+            print(dev['PCI_description'])
+            print("Driver: %s %s" % (dev['Driver'], dev['Driver_version']))
+            print("Firmware: %s" % dev['Firmware_version'])
             driver = dev['Driver']
         if dev['tag'] == 'CPU':
-            print dev['modelname']
+            print(dev['modelname'])
         if dev['tag'] == 'LS':
             if 'product_version' in dev:
-                print dev['PCI_description']
+                print(dev['PCI_description'])
             else:
-                print dev['driver']
+                print(dev['driver'])
                 driver = dev['driver']
         if dev['tag'] == 'OP':
             if 'product_version' in dev:
-                print dev['product_version']
+                print(dev['product_version'])
             else:
-                print dev['version']
+                print(dev['version'])
 
         # CP-30556: Deprecate Marvell (Qlogic) legacy drivers for CH 8.0
         if xs_version >= (8, 0, 0) and driver in DRIVER_BLACK_LIST:
-            print "Error: The driver is already deprecated, " \
-                    "do not list the hardware on HCL!"
+            print("Error: The driver is already deprecated, " \
+                    "do not list the hardware on HCL!")
 
         passed = []
         failed = []
@@ -312,20 +314,20 @@ def validate_test_run(json):
                 ignored.append(test)
 
         if passed:
-            print "Passed:"
+            print("Passed:")
         for t in passed:
-            print t['test_name']
-        print ""
+            print(t['test_name'])
+        print("")
 
         if failed:
-            print "Failed:"
+            print("Failed:")
         for t in failed:
-            print t['test_name']
+            print(t['test_name'])
 
         if ignored:
-            print "Ignored (skipped/other):"
+            print("Ignored (skipped/other):")
         for t in ignored:
-            print t['test_name']
+            print(t['test_name'])
 
 
 def parse_submission(args):
@@ -347,7 +349,7 @@ def parse_submission(args):
     validate_test_run(json)
 
     if args.post:
-        print post_json_to_mongodb(json)
+        print(post_json_to_mongodb(json))
 
 
 def main():

--- a/xscertparser/cmd/acklogparser.py
+++ b/xscertparser/cmd/acklogparser.py
@@ -67,7 +67,6 @@ def result_parser(tarfilename, logsubdir):  # pylint: disable=R0914,R0912
             SERVER_DICT['xs_version'] = version.attributes['xs_version'].value
 
     # CPU info and HBA pci-id info
-    hba_bus_id_list = []
     for device in test_conf.getElementsByTagName("device"):
         if 'family' in device.attributes:
             SERVER_DICT['family'] = device.attributes['family'].value
@@ -85,8 +84,6 @@ def result_parser(tarfilename, logsubdir):  # pylint: disable=R0914,R0912
                 SERVER_DICT['nics'].append(
                     device.attributes['PCI_description'].value
                     )
-        if 'device' in device.attributes:
-            hba_bus_id_list.append(device.attributes['id'].value)
 
     # Chassis used info                 i
     lines = open(dmidecode_path).readlines()

--- a/xscertparser/cmd/acklogparser.py
+++ b/xscertparser/cmd/acklogparser.py
@@ -340,7 +340,7 @@ def parse_submission(args):
     tarball_path = "%s/%s" % (tmpdir, bugtool)
     host = inspector.HostFromTarball(tarball_path)
 
-    inspector.print_system_info(host, ['bios', 'cpu', 'nic', 'storage'])
+    print(inspector.system_info(host, ['bios', 'cpu', 'nic', 'storage']))
     shutil.rmtree(tmpdir)
 
     json = get_json_from_test_run(args.filename)

--- a/xscertparser/tests/test_utils.py
+++ b/xscertparser/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for the utils.py module"""
+from __future__ import print_function
 
+from builtins import str
 import unittest
 import tempfile
 import tarfile
@@ -28,14 +30,14 @@ class TarTestCase(unittest.TestCase):
         os.chdir(tmp_src_dir)
         self.TAR_FILE = "%s/test.tar.gz" % tmp_src_dir
         tar = tarfile.open(str(self.TAR_FILE), 'w:gz')
-        for filename, data in self.TAR_FILES.items():
+        for filename, data in list(self.TAR_FILES.items()):
             tmp_file = "%s/%s" % (self.subdir_n, filename)
             fileh = open(tmp_file, 'w')
             fileh.write(data)
             fileh.close()
             tar.add(tmp_file)
         tar.close()
-        print 'This is the input self.TARFILE %s' % self.TAR_FILE
+        print('This is the input self.TARFILE %s' % self.TAR_FILE)
 
     def _extract_file_from_tar(self, fpath, fullpathknown=True):
         """Test the means of extracting a file"""
@@ -52,7 +54,7 @@ class TarTestCase(unittest.TestCase):
 
     def test_extraction_using_fullpath(self):
         """Test the means of extracting a file"""
-        print 'This is the input self.TARFILE %s' % self.TAR_FILE
+        print('This is the input self.TARFILE %s' % self.TAR_FILE)
         self._extract_file_from_tar('subdir/testfile3')
 
     def test_pextraction_using_regex(self):
@@ -63,8 +65,8 @@ class TarTestCase(unittest.TestCase):
         """Negative Test to test the means of extracting a file"""
         try:
             self._extract_file_from_tar('testfile', False)
-        except Exception, e:
+        except Exception as e:
             if 'None or more than one' not in str(e):
                 raise e
-            print "Returned exception as expected for an entry with \
-                   on-unique regex"
+            print("Returned exception as expected for an entry with \
+                   on-unique regex")

--- a/xscertparser/utils.py
+++ b/xscertparser/utils.py
@@ -24,5 +24,5 @@ def extract_file_from_tar(tarfilepath, fpath, dest, fullpathknown=True):
 def get_tarpaths_using_regex(tarfilepath, regex):
     """Get filepaths list available in tar archive from the given regex"""
     tarf = tarfile.open(tarfilepath)
-    path = filter(lambda x: re.search(regex, x), tarf.getnames())
+    path = [x for x in tarf.getnames() if re.search(regex, x)]
     return path

--- a/xscertparser/xmltojson.py
+++ b/xscertparser/xmltojson.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from builtins import range
 from pymongo import MongoClient
 import xml.dom.minidom
 import json
@@ -74,7 +75,7 @@ def get_device_test_record(node):
     rec = {}
 
     attrs = get_attributes(node)
-    for k, v in attrs.iteritems():
+    for k, v in attrs.items():
         rec[k] = v
 
     cert_tests = get_child_elems(node)

--- a/xsjira/models.py
+++ b/xsjira/models.py
@@ -1,5 +1,7 @@
 """Module for Jira bindings onto XS tracker instance"""
+from __future__ import print_function
 
+from builtins import object
 import os
 import tempfile
 from xscertparser.cmd.acklogparser import result_parser
@@ -69,7 +71,7 @@ class JiraTicket(object):
 
     def assign_issue(self, user):
         """Assign the issue to a specified user"""
-        print user
+        print(user)
         return self.jira.assign_issue(self.key, user)
 
     def list_comments(self):
@@ -115,7 +117,7 @@ class HCLSubmission(JiraTicket):
         for afile in self.issue.fields.attachment:
             if 'ack-submission' in afile.filename:
                 return (self.get_attachment_path(afile.id), afile.filename)
-        print "Error: ACK Submission Log is missing in this HCL Submission"
+        print("Error: ACK Submission Log is missing in this HCL Submission")
         return (None, None)
 
     def get_ack_attachment_dict(self, att_path):  # pylint: disable=R0201


### PR DESCRIPTION
Add support for python3, so that the ack-results-parser can be used with python2 or python3

python-hwinfo can't be used from pypi because it is python2 only.  This package depends on this pull request in `python-hwinfo`: https://github.com/rdobson/python-hwinfo/pull/25 , which adds python3 support to `python-hwinfo`.