### PR TITLE
CA-392424: don't crash if no driver was recorded for storage

### DIFF
--- a/xscertparser/cmd/acklogparser.py
+++ b/xscertparser/cmd/acklogparser.py
@@ -284,7 +284,7 @@ def validate_test_run(json):
         if dev['tag'] == 'LS':
             if 'product_version' in dev:
                 print(dev['PCI_description'])
-            else:
+            elif "driver" in dev:
                 print(dev['driver'])
                 driver = dev['driver']
         if dev['tag'] == 'OP':


### PR DESCRIPTION
If the ack submission does not contain a driver for storage, don't crash the parser.  Skip the driver for storage and print the rest of the results.