### PR TITLE
CP-312582 Restore acklogparser to work with tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prerequisites
 - Network access to the configured repo URLs (used by the RPM comparison)
 - `dnf repoquery` (preferred) or `repoquery` available on PATH
 - `python-hwinfo` / `hwinfo` (required for printing BIOS/CPU/NIC/Storage summary)
+- `jira` Python package (required for `-t` option)
 
 Install
 
@@ -22,7 +23,28 @@ Install
 
 Run
 
-- `acklogparser -f <ack-submission-*.tar.gz>`
+- Local file:
+
+  `acklogparser -f <ack-submission-*.tar.gz>`
+
+- From tracker (downloads latest submission, parses, and posts output as comment):
+
+  `acklogparser -t HCL-1234`
+
+- Process specific attachment (specify attachment name after colon):
+
+  `acklogparser -t HCL-1234:attachment-name`
+
+  Authentication: Set environment variables `JIRA_USER` (email) and `JIRA_TOKEN` (API token)
+
+  To generate an API token:
+  1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+  2. Click "Create API token"
+  3. Copy the token and set:
+     ```
+     export JIRA_USER="your.email@company.com"
+     export JIRA_TOKEN="your-api-token"
+     ```
 
 
 Dependencies

--- a/xscertparser/cmd/acklogparser.py
+++ b/xscertparser/cmd/acklogparser.py
@@ -4,17 +4,18 @@
 from argparse import ArgumentParser
 from xscertparser.utils import extract_file_from_tar
 from xscertparser import xmltojson
+from hwinfo.tools import inspector
+from pymongo import MongoClient
 import os
 import re
 import subprocess
+import sys
 import urllib.request
 import xml.dom.minidom
 import pprint
-from hwinfo.tools import inspector
 import tempfile
 import shutil
 import tarfile
-from pymongo import MongoClient
 # import models
 
 NICS_DICT = {}
@@ -263,6 +264,9 @@ def extract_rpm_qa_and_inventory_from_submission(tar_gz_file):
 
 def compare_submission_rpms_with_repos(tar_gz_file):
     rpm_dict1, product_version = extract_rpm_qa_and_inventory_from_submission(tar_gz_file)
+    if product_version not in REPO_CONFIG:
+        print("\nProduct version '%s' not in REPO_CONFIG, skipping repo comparison\n" % product_version)
+        return
     repo_urls = REPO_CONFIG[product_version]
     rpm_dict2 = parse_repo_urls(repo_urls)
     rpm_dict2.update(DEFAULT_ACK_RPMS.get(product_version, {}))
@@ -524,11 +528,13 @@ def validate_test_run(json):
         if dev['tag'] == 'CPU':
             print(dev['modelname'])
         if dev['tag'] == 'LS':
-            if 'product_version' in dev:
+            if 'PCI_description' in dev:
                 print(dev['PCI_description'])
-            elif "driver" in dev:
-                print(dev['driver'])
-                driver = dev['driver']
+            if 'Driver' in dev:
+                print("Driver: %s %s" % (dev['Driver'], dev['Driver_version']))
+                driver = dev['Driver']
+            if 'Firmware_version' in dev:
+                print("Firmware: %s" % dev['Firmware_version'])
         if dev['tag'] == 'OP':
             if 'product_version' in dev:
                 print(dev['product_version'])
@@ -591,12 +597,74 @@ def parse_submission(args):
         print(post_json_to_mongodb(json))
 
 
+TRACKER_URL = 'https://xenserver-tracker.atlassian.net'
+
+
+def get_tracker_ticket(ticket_id):
+    """Get ticket from tracker. Auth via JIRA_USER/JIRA_TOKEN env vars."""
+    from jira.client import JIRA
+    from jira.exceptions import JIRAError
+    from xsjira.models import GenericSubmission
+    user, token = os.environ.get('JIRA_USER'), os.environ.get('JIRA_TOKEN')
+    if not user or not token:
+        print("Error: JIRA_USER and JIRA_TOKEN environment variables are required.")
+        print("Set them with your Atlassian email and API token:")
+        print("  export JIRA_USER='your.email@company.com'")
+        print("  export JIRA_TOKEN='your-api-token'")
+        sys.exit(1)
+    try:
+        jira = JIRA(server=TRACKER_URL, basic_auth=(user, token))
+        return GenericSubmission(jira, ticket_id)
+    except JIRAError as e:
+        if e.status_code == 404:
+            print("Error: Issue '%s' does not exist or you do not have permission to see it." % ticket_id)
+        elif e.status_code == 401:
+            print("Error: Authentication failed. Check your JIRA_USER and JIRA_TOKEN.")
+        else:
+            print("Error: %s" % e.text)
+        sys.exit(1)
+
+
 def main():
     """Entry point"""
     parser = ArgumentParser()
-    parser.add_argument("-f", "--file", dest="filename", required=True,
-                        help="ACK tar file")
+    parser.add_argument("-f", "--file", dest="filename",
+                        help="ACK tar file (local path)")
+    parser.add_argument("-t", "--ticket", dest="ticket",
+                        help="Tracker ticket ID (e.g. HCL-1234 or HCL-1234:filename.zip)")
     parser.add_argument("-p", "--post", dest="post", action="store_true")
     args = parser.parse_args()
-    parse_submission(args)
-    compare_submission_rpms_with_repos(args.filename)
+
+    if args.ticket:
+        # Parse ticket:attachment_name format
+        if ':' in args.ticket:
+            ticket_id, attachment_name = args.ticket.rsplit(':', 1)
+        else:
+            ticket_id, attachment_name = args.ticket, None
+
+        ticket = get_tracker_ticket(ticket_id)
+        attachments = ticket.get_ack_attachment(attachment_name)
+        if not attachments:
+            print("No ack-submission found in %s" % ticket_id)
+            return
+
+        import io, sys
+        for ack_path, ack_name in attachments:
+            print("Processing: %s" % ack_name)
+            args.filename = ack_path
+
+            buf = io.StringIO()
+            sys.stdout = buf
+            parse_submission(args)
+            compare_submission_rpms_with_repos(args.filename)
+            sys.stdout = sys.__stdout__
+
+            output = buf.getvalue()
+            print(output)
+            ticket.add_comment("{code:none}\n%s\n{code}" % output)
+            print("[Comment posted to %s for %s]" % (ticket.key, ack_name))
+    else:
+        if not args.filename:
+            parser.error("Either -f/--file or -t/--ticket is required")
+        parse_submission(args)
+        compare_submission_rpms_with_repos(args.filename)

--- a/xsjira/models.py
+++ b/xsjira/models.py
@@ -50,10 +50,10 @@ class JiraTicket(object):
     def get_attachment_path(self, aid):
         """Returns attachment file path"""
         att_obj = self.get_attachment_object(aid)
-        url = att_obj.raw['content']
         (fileh, attachment_path) = tempfile.mkstemp()
         os.close(fileh)
-        os.system("curl -n %s -o %s -s" % (url, attachment_path))
+        with open(attachment_path, 'wb') as f:
+            f.write(att_obj.get())
         return attachment_path
 
     def create_issue_link(self, remote_key):
@@ -112,13 +112,56 @@ class HCLSubmission(JiraTicket):
         if self.get_type() != 'HCL Submission':
             raise Exception("Not a HCL Submission! (%s)" % self.get_type())
 
-    def get_ack_attachment(self):
-        """Returns tuple of (ack_path, ack_filename)"""
-        for afile in self.issue.fields.attachment:
-            if 'ack-submission' in afile.filename:
-                return (self.get_attachment_path(afile.id), afile.filename)
-        print("Error: ACK Submission Log is missing in this HCL Submission")
-        return (None, None)
+    def get_ack_attachment(self, attachment_name=None):
+        """Returns list of (ack_path, ack_filename) tuples from a single attachment."""
+        import zipfile
+        import os
+        
+        # Assign ticket to JIRA_USER before downloading attachment
+        jira_user = os.environ.get('JIRA_USER')
+        if jira_user:
+            self.assign_issue(jira_user)
+        
+        # Find target attachment
+        if attachment_name:
+            targets = [f for f in self.issue.fields.attachment if f.filename == attachment_name]
+        else:
+            targets = [f for f in self.issue.fields.attachment 
+                      if 'ack-submission' in f.filename or f.filename.endswith('.zip')]
+            targets.sort(key=lambda f: f.created, reverse=True)
+        
+        if not targets:
+            print("Error: No matching attachment found")
+            return []
+        target = targets[0]
+        
+        # Direct ack-submission file
+        if 'ack-submission' in target.filename:
+            path = self.get_attachment_path(target.id)
+            return [(path, target.filename)]
+        
+        # Zip file - extract all ack-submissions inside
+        if target.filename.endswith('.zip'):
+            zip_path = self.get_attachment_path(target.id)
+            result = []
+            try:
+                with zipfile.ZipFile(zip_path, 'r') as z:
+                    extract_dir = tempfile.mkdtemp()
+                    for name in z.namelist():
+                        if 'ack-submission' in name and '.tar' in name:
+                            z.extract(name, extract_dir)
+                            result.append((os.path.join(extract_dir, name), os.path.basename(name)))
+                            print("Found: %s" % os.path.basename(name))
+            except zipfile.BadZipFile:
+                print("Bad zip file: %s" % target.filename)
+                return []
+            if not result:
+                print("Error: No ack-submission found in %s" % target.filename)
+            result.sort(key=lambda x: x[1], reverse=True)
+            return result
+        
+        print("Error: '%s' is not an ack-submission or zip file" % target.filename)
+        return []
 
     def get_ack_attachment_dict(self, att_path):  # pylint: disable=R0201
         """if type ==Server, Prints dict and returns Dict"""


### PR DESCRIPTION
The code change extends acklogparser to allow it to fetch ack-submission files directly from a tracker ticket and write the parsing results back to the tracker. acklogparser now supports the following features:

- Parse ack-submission files locally.
- Fetch the latest compressed file from a tracker ticket attachment and write the parsed output back to the tracker. If the attachment is a ZIP file containing multiple ack-submission files, all submissions will be parsed. A separate comment will be generated for each ack-submission.

Additionally, acklogparser will automatically update the ticket assignee to the account used to access the tracker system.

I've verified following cases
acklogparser -f <ack-submission-*.tar.gz>
acklogparser -t ticket
acklogparser -t ticket:attachment